### PR TITLE
Add Linux agent install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # step-agent-plugin
 
-The Smallstep agent runs on your devices to securely manage end-to-end certificate lifecycle for all your Managed Workloads. It handles device enrollment and workload certificate management for a broad range of workload types.
+The Smallstep agent runs on your endpoints to securely manage end-to-end enrollment, device and workload inventory, and credential lifecycle. It handles device identity and hardware-bound, attested credentials for a broad range of use cases.
 
-This plugin is for users of [Smallstep Certificate Manager](https://smallstep.com/).
+This plugin is for users of [Smallstep Device Identity](https://smallstep.com/).
 
 ## Installation
 
@@ -12,10 +12,3 @@ For install instructions across all platforms, see [Installing the Smallstep Age
 
 The [`smallstep-agent-install.sh`](smallstep-agent-install.sh) script automates agent installation on supported Linux distributions. See the [packages.smallstep.com](https://github.com/smallstep/packages.smallstep.com) repo for GCS deployment instructions.
 
-### Testing
-
-Run the test script to validate the installer across all supported distros using Docker:
-
-```bash
-bash scripts/test-smallstep-agent-installer.sh
-```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The [`smallstep-agent-install.sh`](smallstep-agent-install.sh) script installs t
 - Fedora
 - RHEL, CentOS Stream, Rocky Linux, AlmaLinux
 - Debian, Ubuntu
+- Arch Linux variants
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -4,30 +4,13 @@ The Smallstep agent runs on your devices to securely manage end-to-end certifica
 
 This plugin is for users of [Smallstep Certificate Manager](https://smallstep.com/).
 
-## Linux Installer
+## Installation
 
-The [`smallstep-agent-install.sh`](smallstep-agent-install.sh) script installs the Smallstep agent on supported Linux distributions:
+For install instructions across all platforms, see [Installing the Smallstep Agent](https://smallstep.com/docs/platform/smallstep-app/).
 
-- Fedora
-- RHEL, CentOS Stream, Rocky Linux, AlmaLinux
-- Debian, Ubuntu
-- Arch Linux variants
+## Linux Installer Script
 
-### Usage
-
-Download and run:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/smallstep/step-agent-plugin/main/smallstep-agent-install.sh -o smallstep-agent-install.sh
-sudo bash smallstep-agent-install.sh --team <your-team>
-```
-
-To pin to a specific version, use a commit SHA or tag:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/smallstep/step-agent-plugin/<commit-sha>/smallstep-agent-install.sh -o smallstep-agent-install.sh
-sudo bash smallstep-agent-install.sh --team <your-team>
-```
+The [`smallstep-agent-install.sh`](smallstep-agent-install.sh) script automates agent installation on supported Linux distributions. See the [packages.smallstep.com](https://github.com/smallstep/packages.smallstep.com) repo for GCS deployment instructions.
 
 ### Testing
 
@@ -36,7 +19,3 @@ Run the test script to validate the installer across all supported distros using
 ```bash
 bash scripts/test-smallstep-agent-installer.sh
 ```
-
-### GCS Deployment
-
-This script is also deployed to GCS and served at `https://packages.smallstep.com/scripts/smallstep-agent-install.sh`. See the [packages.smallstep.com](https://github.com/smallstep/packages.smallstep.com) repo for upload instructions.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,41 @@
 # step-agent-plugin
 
-The Smallstep agent runs your devices to securely manage end-to-end certificate lifecycle for all your Managed Workloads. It handles device enrollment and workload certificate management for a broad range of workload types.
+The Smallstep agent runs on your devices to securely manage end-to-end certificate lifecycle for all your Managed Workloads. It handles device enrollment and workload certificate management for a broad range of workload types.
 
 This plugin is for users of [Smallstep Certificate Manager](https://smallstep.com/).
+
+## Linux Installer
+
+The [`smallstep-agent-install.sh`](smallstep-agent-install.sh) script installs the Smallstep agent on supported Linux distributions:
+
+- Fedora
+- RHEL, CentOS Stream, Rocky Linux, AlmaLinux
+- Debian, Ubuntu
+
+### Usage
+
+Download and run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/smallstep/step-agent-plugin/main/smallstep-agent-install.sh -o smallstep-agent-install.sh
+sudo bash smallstep-agent-install.sh --team <your-team>
+```
+
+To pin to a specific version, use a commit SHA or tag:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/smallstep/step-agent-plugin/<commit-sha>/smallstep-agent-install.sh -o smallstep-agent-install.sh
+sudo bash smallstep-agent-install.sh --team <your-team>
+```
+
+### Testing
+
+Run the test script to validate the installer across all supported distros using Docker:
+
+```bash
+bash scripts/test-smallstep-agent-installer.sh
+```
+
+### GCS Deployment
+
+This script is also deployed to GCS and served at `https://packages.smallstep.com/scripts/smallstep-agent-install.sh`. See the [packages.smallstep.com](https://github.com/smallstep/packages.smallstep.com) repo for upload instructions.

--- a/scripts/test-smallstep-agent-installer.sh
+++ b/scripts/test-smallstep-agent-installer.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+DISTRO_CONTAINER_LIST=(fedora:latest redhat/ubi9:latest quay.io/centos/centos:stream9 almalinux:latest rockylinux/rockylinux:9.3.20231119 debian:latest ubuntu:latest gentoo/stage3:systemd)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+TEST_REPORT=()
+
+for DISTRO in "${DISTRO_CONTAINER_LIST[@]}"; do
+  DISTRO_NICKNAME="${DISTRO%%:*}"
+  DISTRO_NICKNAME="${DISTRO_NICKNAME//\//-}"
+  echo "Testing smallstep-agent-install.sh on ${DISTRO_NICKNAME}..."
+  set e
+  docker run -it --rm \
+      --name "test-smallstep-agent-install-${DISTRO_NICKNAME}" \
+      -e STEP_AGENT_TEAM=foo \
+      -e DEBIAN_FRONTEND=noninteractive \
+      -v ${SCRIPT_DIR}/../smallstep-agent-install.sh:/smallstep-agent-install.sh:Z \
+      "${DISTRO}" \
+      ./smallstep-agent-install.sh || EXITCODE=$?
+  set -e
+  if [[ "${EXITCODE}" -ne 1 ]]; then
+    TEST_REPORT+=("${DISTRO}: Passed!")
+  else
+    TEST_REPORT+=("${DISTRO}: Failed!")
+  fi
+done
+
+echo ""
+echo "Smallstep Agent Installer Test Report"
+printf '%s\n' "${TEST_REPORT[@]}"

--- a/smallstep-agent-install.sh
+++ b/smallstep-agent-install.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (C) 2022 Smallstep Labs, Inc. All Rights Reserved.
+#
+# This script is the source of truth for the Smallstep agent Linux installer.
+# It is also deployed to GCS and served at:
+#   https://packages.smallstep.com/scripts/smallstep-agent-install.sh
+#
+# For GCS upload instructions, see the README in the packages.smallstep.com repo:
+#   https://github.com/smallstep/packages.smallstep.com
+
+set -eo pipefail
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+helptext(){
+cat <<'EOF'
+
+                       smallstep-agent-install.sh
+                Register smallstep agent on smallstep.com
+                 or your smallstep run-anywhere cluster
+
+                      https://u.step.sm/docs/agent
+
+                          Copyright (C) 2025
+                          Smallstep Labs, Inc
+                          All Rights Reserved
+
+                    SPDX-License-Identifier: Apache-2.0
+
+     Example:
+    ./smallstep-agent-install.sh --team example
+
+    Required Flags or Environment Variables:
+        --team example
+        STEP_AGENT_TEAM=example
+
+    Environment variables:
+
+        STEP_AGENT_TEAM=example
+
+    Configuration precedence for required variables:
+    1) Flags
+    2) Environment variables
+    3) Prompts
+
+    Notes:
+
+    If this script was downloaded from inside your smallstep account
+    it might have STEP_AGENT_TEAM automatically set. This will override
+    the --team flag and the STEP_AGENT_TEAM environment variable and it
+    will also disable promting for a team.
+
+    Comment it out if you want to enable the --team flag, STEP_AGENT_TEAM
+    environment variable, and prompting for a team when the script is run.
+
+EOF
+exit 0
+}
+
+if ! [ $(id -u) = 0 ]; then
+   echo "This script must be run as root."
+   exit 1
+fi
+
+# Get CPU Architecture
+GNUARCH=$(uname -m)
+case $GNUARCH in
+    x86_64) ARCH="amd64" ;;
+    x86) ARCH="386" ;;
+    i686) ARCH="386" ;;
+    i386) ARCH="386" ;;
+    aarch64) ARCH="arm64" ;;
+    armv5*) ARCH="armv5" ;;
+    armv6*) ARCH="armv6" ;;
+    armv7*) ARCH="armv7" ;;
+esac
+
+if [[ "${ARCH}" != "amd64" && "${ARCH}" != "arm64" ]]; then
+    echo "This script only works on x86_64 and arm64 systems, for now."
+    exit 1
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --team)
+            STEP_AGENT_TEAM="$2"
+            shift
+            shift
+            ;;
+        --help)
+            helptext
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+
+## Start Template
+# STEP_AGENT_TEAM={{ .TeamSlug }}
+# Comment the line above to disable the team that was automatically set when
+# it was downloaded from your smallstep account.
+## End Template
+
+if [[ -v STEP_AGENT_TEAM ]]; then
+    TEAM=${STEP_AGENT_TEAM}
+else
+    if [ -t 0 ] ; then
+      echo ""
+      echo "A team is required!"
+      read -p "Team: " TEAM
+      TEAM=${TEAM}
+    else
+      echo "A smallstep team is required!"
+      echo ""
+      echo "Pipe detected!"
+      echo "Rerun with STEP_AGENT_TEAM environment variable set or download"
+      echo "and run the script manually to enable flags and prompts to"
+      echo "set your team."
+      echo ""
+      helptext
+      exit 1
+    fi
+fi
+
+if [ "$(grep -Ei 'fedora|redhat|centos|rocky|almalinux|debian|buntu' /etc/*release)" ]; then
+
+  DISTRO=$(grep ^ID= /etc/os-release | cut -d'=' -f2 | tr -d '"')
+
+  if [[ "$DISTRO" =~ ^(rhel|centos|rocky|almalinux)$ ]]; then
+    echo "Setting up the YUM/DNF repository for ${DISTRO}..."
+
+    cat << EOT > /etc/yum.repos.d/smallstep.repo
+[smallstep]
+name=Smallstep
+baseurl=https://packages.smallstep.com/stable/el/
+enabled=1
+repo_gpgcheck=0
+gpgcheck=1
+gpgkey=https://packages.smallstep.com/keys/smallstep-0x889B19391F774443.gpg
+EOT
+
+  dnf makecache
+  dnf install --best -y step-agent-plugin
+  fi
+
+  if [[ "$DISTRO" == "fedora" ]]; then
+    echo "Setting up the DNF repository for ${DISTRO}..."
+
+    cat << EOT > /etc/yum.repos.d/smallstep.repo
+[smallstep]
+name=Smallstep
+baseurl=https://packages.smallstep.com/stable/fedora/
+enabled=1
+repo_gpgcheck=0
+gpgcheck=1
+gpgkey=https://packages.smallstep.com/keys/smallstep-0x889B19391F774443.gpg
+EOT
+
+  dnf makecache
+  dnf install --best -y step-agent-plugin
+  fi
+
+  if [ "$(grep -Ei 'debian|buntu' /etc/*release)" ]; then
+    echo "Setting up the Apt repository for ${DISTRO}..."
+    apt-get update && apt-get install -y --no-install-recommends curl vim gpg ca-certificates
+    curl -fsSL https://packages.smallstep.com/keys/apt/repo-signing-key.gpg -o /etc/apt/trusted.gpg.d/smallstep.asc
+    cat << EOT > /etc/apt/sources.list.d/smallstep.list
+deb [signed-by=/etc/apt/trusted.gpg.d/smallstep.asc] https://packages.smallstep.com/stable/debian debs main
+EOT
+  apt-get update && apt-get -y install step-agent-plugin
+  fi
+
+else
+  echo "Only the following Linux distributions are supported at this time:"
+  echo ""
+  echo "Fedora, RHEL, Centos Stream, Rocky Linux, AlmaLinux, Debian, and Ubuntu"
+  exit 1
+fi
+echo ""
+echo "The Smallstep agent has been installed!"
+echo ""
+step-agent-plugin version
+echo ""
+
+if [[ -f /.dockerenv ]] || [[ "$container" =~ ^(oci|podman)$ ]]; then
+  echo ""
+  echo "Container detected! Skipping enabling and starting step-agent systemd service!"
+  echo ""
+  exit 0
+else
+  echo ""
+  echo "Enabling and starting step-agent.service..."
+  systemctl enable --now step-agent.service
+  systemctl enable --now step-agent-restart.path
+  echo ""
+  echo "To continue, register this device with your Smallstep team:"
+  echo ""
+  echo "${bold}sudo step-agent-plugin register ${TEAM}${normal}"
+  echo ""
+fi
+

--- a/smallstep-agent-install.sh
+++ b/smallstep-agent-install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # SPDX-License-Identifier: Apache-2.0
 #
 # Copyright (C) 2022 Smallstep Labs, Inc. All Rights Reserved.
@@ -22,7 +22,7 @@ cat <<'EOF'
                 Register smallstep agent on smallstep.com
                  or your smallstep run-anywhere cluster
 
-                      https://u.step.sm/docs/agent
+                    https://smallstep.com/docs/agent
 
                           Copyright (C) 2025
                           Smallstep Labs, Inc
@@ -107,26 +107,9 @@ done
 
 if [[ -v STEP_AGENT_TEAM ]]; then
     TEAM=${STEP_AGENT_TEAM}
-else
-    if [ -t 0 ] ; then
-      echo ""
-      echo "A team is required!"
-      read -p "Team: " TEAM
-      TEAM=${TEAM}
-    else
-      echo "A smallstep team is required!"
-      echo ""
-      echo "Pipe detected!"
-      echo "Rerun with STEP_AGENT_TEAM environment variable set or download"
-      echo "and run the script manually to enable flags and prompts to"
-      echo "set your team."
-      echo ""
-      helptext
-      exit 1
-    fi
 fi
 
-if [ "$(grep -Ei 'fedora|redhat|centos|rocky|almalinux|debian|buntu' /etc/*release)" ]; then
+if [ "$(grep -Ei 'fedora|redhat|centos|rocky|almalinux|debian|buntu|arch' /etc/*release)" ]; then
 
   DISTRO=$(grep ^ID= /etc/os-release | cut -d'=' -f2 | tr -d '"')
 
@@ -174,10 +157,27 @@ EOT
   apt-get update && apt-get -y install step-agent-plugin
   fi
 
+  if [ "$(grep -Ei 'arch' /etc/*release)" ]; then
+    echo "Installing step-agent-plugin for ${DISTRO}..."
+
+    VERSION=$(curl -fsSL https://api.github.com/repos/smallstep/step-agent-plugin/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
+    if [[ -z "$VERSION" ]]; then
+      echo "Failed to determine the latest step-agent-plugin version."
+      exit 1
+    fi
+
+    PKG_URL="https://github.com/smallstep/step-agent-plugin/releases/download/v${VERSION}/step-agent-plugin-${VERSION}-1-${GNUARCH}.pkg.tar.zst"
+
+    echo "Downloading step-agent-plugin ${VERSION}..."
+    curl -fsSL -o "/tmp/step-agent-plugin-${VERSION}-1-${GNUARCH}.pkg.tar.zst" "$PKG_URL"
+    pacman -U --noconfirm "/tmp/step-agent-plugin-${VERSION}-1-${GNUARCH}.pkg.tar.zst"
+    rm -f "/tmp/step-agent-plugin-${VERSION}-1-${GNUARCH}.pkg.tar.zst"
+  fi
+
 else
   echo "Only the following Linux distributions are supported at this time:"
   echo ""
-  echo "Fedora, RHEL, Centos Stream, Rocky Linux, AlmaLinux, Debian, and Ubuntu"
+  echo "Fedora, RHEL, Centos Stream, Rocky Linux, AlmaLinux, Debian, Ubuntu, and Arch Linux variants"
   exit 1
 fi
 echo ""
@@ -196,10 +196,18 @@ else
   echo "Enabling and starting step-agent.service..."
   systemctl enable --now step-agent.service
   systemctl enable --now step-agent-restart.path
+fi
+
+if [ -z "$TEAM" ]; then
+  echo ""
+  echo "To continue, register this device with your Smallstep team:"
+  echo ""
+  echo "${bold}sudo step-agent-plugin register <team-slug>${normal}"
+  echo ""
+else
   echo ""
   echo "To continue, register this device with your Smallstep team:"
   echo ""
   echo "${bold}sudo step-agent-plugin register ${TEAM}${normal}"
   echo ""
 fi
-


### PR DESCRIPTION
## Summary
- Moved `smallstep-agent-install.sh` and test script from `packages.smallstep.com`
- Added provenance comment linking back to `packages.smallstep.com` for GCS deployment docs
- Updated README with install script documentation and versioned URL examples

## Context
Customers need a public, versioned GitHub URL for the install script. GCS doesn't provide version visibility. This repo is public, so customers can pin to a commit SHA or tag and see change history.

Companion PR in packages.smallstep.com will follow (adds this repo as submodule, updates upload recipe).