### PR TITLE
install: fetch Arch package from packages.smallstep.com (EFF-173)

### DIFF
--- a/smallstep-agent-install.sh
+++ b/smallstep-agent-install.sh
@@ -160,18 +160,13 @@ EOT
   if [ "$(grep -Ei 'arch' /etc/*release)" ]; then
     echo "Installing step-agent for ${DISTRO}..."
 
-    VERSION=$(curl -fsSL https://api.github.com/repos/smallstep/step-agent-plugin/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
-    if [[ -z "$VERSION" ]]; then
-      echo "Failed to determine the latest step-agent version."
-      exit 1
-    fi
+    PKG_URL="https://packages.smallstep.com/stable/linux/step-agent_${ARCH}_latest.pkg.tar.zst"
+    PKG_FILE="/tmp/step-agent_${ARCH}_latest.pkg.tar.zst"
 
-    PKG_URL="https://github.com/smallstep/step-agent-plugin/releases/download/v${VERSION}/step-agent-${VERSION}-1-${GNUARCH}.pkg.tar.zst"
-
-    echo "Downloading step-agent ${VERSION}..."
-    curl -fsSL -o "/tmp/step-agent-${VERSION}-1-${GNUARCH}.pkg.tar.zst" "$PKG_URL"
-    pacman -U --noconfirm "/tmp/step-agent-${VERSION}-1-${GNUARCH}.pkg.tar.zst"
-    rm -f "/tmp/step-agent-${VERSION}-1-${GNUARCH}.pkg.tar.zst"
+    echo "Downloading step-agent..."
+    curl -fsSL -o "$PKG_FILE" "$PKG_URL"
+    pacman -U --noconfirm "$PKG_FILE"
+    rm -f "$PKG_FILE"
   fi
 
 else


### PR DESCRIPTION
## Summary
- Replace the GitHub-API version-scrape + `github.com/.../releases/download/...` download with a single fetch of `https://packages.smallstep.com/stable/linux/step-agent_${ARCH}_latest.pkg.tar.zst`.
- Brings the Arch install branch in line with how the deb/rpm/dnf branches already resolve packages from `packages.smallstep.com`.
- Drops the dependency on unauthenticated GitHub API calls (rate-limited and prone to 403 from CI/shared egress IPs).

The `_latest` pointer is now populated by the EFF-170 promote-latest workflow ([smallstep/agent#1003](https://github.com/smallstep/agent/pull/1003)), and both `amd64` and `arm64` objects are live in GCS.

Closes EFF-173.

## Test plan
- [ ] On an Arch x86_64 host: `sudo bash smallstep-agent-install.sh --team <slug>` — installs and registers
- [x] On an Arch arm64 host: `sudo bash smallstep-agent-install.sh --team <slug>` — installs and registers
- [x] `curl -fI https://packages.smallstep.com/stable/linux/step-agent_amd64_latest.pkg.tar.zst` returns 200 (after redirect)
- [x] `curl -fI https://packages.smallstep.com/stable/linux/step-agent_arm64_latest.pkg.tar.zst` returns 200 (after redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)