### PR TITLE
Deprecate step-agent-plugin and provide new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# step-agent-plugin
+# step-agent
+
+## [2026-06-17] This repo is deprecated and will soon be deleted.
+Please use [https://releases.smallstep.com](https://releases.smallstep.com) instead.
 
 The Smallstep agent runs on your endpoints to securely manage end-to-end enrollment, device and workload inventory, and credential lifecycle. It handles device identity and hardware-bound, attested credentials for a broad range of use cases.
 


### PR DESCRIPTION
Updated README to indicate deprecation and provide new link.
